### PR TITLE
Updates

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: acceptance
         run: script/acceptance

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
 
       - name: acceptance
         run: script/acceptance

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -14,7 +14,9 @@ permissions:
 
 jobs:
   deploy:
-    environment: production-secrets
+    environment:
+      name: production
+      deployment: false
     if: # only run on pull request comments and very specific comment body string as defined in our branch-deploy settings
       ${{ github.event.issue.pull_request &&
       (contains(github.event.comment.body, '.deploy') ||
@@ -26,17 +28,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: github/branch-deploy@v10
+      - uses: github/branch-deploy@v11.1.2
         id: branch-deploy
         with:
-          admins: the-hideout/core-contributors
-          admins_pat: ${{ secrets.BRANCH_DEPLOY_ADMINS_PAT }}
+          admins: GrantBirki,Razzmatazzz
           environment_targets: production
           sticky_locks: "true"
 
       - name: checkout
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.branch-deploy.outputs.sha }}
 

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: github/branch-deploy@v11.1.2
+      - uses: github/branch-deploy@fded0351b6b79f854b335c11b3d93063461dd288 # pin@v11.1.2
         id: branch-deploy
         with:
           admins: GrantBirki,Razzmatazzz
@@ -37,7 +37,7 @@ jobs:
 
       - name: checkout
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:
           ref: ${{ steps.branch-deploy.outputs.sha }}
 

--- a/.github/workflows/config-validation.yml
+++ b/.github/workflows/config-validation.yml
@@ -14,10 +14,10 @@ jobs:
   json-yaml-validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
 
       - name: json-yaml-validate
-        uses: GrantBirki/json-yaml-validate@v3.3.0
+        uses: GrantBirki/json-yaml-validate@947ae8ac60c83cf78e4e00b3170ff8bee61f5248 # pin@v3.3.0
         with:
           comment: "true"
           json_schema: "config/schema.json"

--- a/.github/workflows/config-validation.yml
+++ b/.github/workflows/config-validation.yml
@@ -14,7 +14,7 @@ jobs:
   json-yaml-validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: json-yaml-validate
         uses: GrantBirki/json-yaml-validate@v3.3.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # https://github.com/github/branch-deploy/blob/d3c24bd92505e623615b75ffdfac5ed5259adbdb/docs/merge-commit-strategy.md
       - name: deployment check
-        uses: github/branch-deploy@v11.1.2
+        uses: github/branch-deploy@fded0351b6b79f854b335c11b3d93063461dd288 # pin@v11.1.2
         id: deployment-check
         with:
           merge_deploy_mode: "true"
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:
           ref: ${{ needs.deployment-check.outputs.sha }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # https://github.com/github/branch-deploy/blob/d3c24bd92505e623615b75ffdfac5ed5259adbdb/docs/merge-commit-strategy.md
       - name: deployment check
-        uses: github/branch-deploy@v10
+        uses: github/branch-deploy@v11.1.2
         id: deployment-check
         with:
           merge_deploy_mode: "true"
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.deployment-check.outputs.sha }}
 
@@ -43,5 +43,4 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
-          script_stop: true
           script: ~/cache/script/deploy -r "main" -d "/home/${{ secrets.SSH_USERNAME }}/cache"

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       # Comment on new PR requests with deployment instructions
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: comment
         uses: GrantBirki/comment@v2.1.0
         continue-on-error: true

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
       # Comment on new PR requests with deployment instructions
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
       - name: comment
-        uses: GrantBirki/comment@v2.1.0
+        uses: GrantBirki/comment@f524ee31407667c05061bad41e1758b40298bd82 # pin@v2.1.0
         continue-on-error: true
         with:
           file: .github/new-pr-comment.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'src/cache/go.mod'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
 
       - name: setup go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # pin@v6
         with:
           go-version-file: 'src/cache/go.mod'
 

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: github/branch-deploy@v11.1.2
+        uses: github/branch-deploy@fded0351b6b79f854b335c11b3d93063461dd288 # pin@v11.1.2
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: github/branch-deploy@v10
+        uses: github/branch-deploy@v11.1.2
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 services:
   redis:
     container_name: redis
-    image: redis:alpine3.16
+    image: redis:alpine3.16@sha256:2700d5097763fda285c463f4eefc3d0730a2df2a9d48e66707b19d5a5e5f23d4
     restart: unless-stopped
     command:
       [

--- a/src/cache/Dockerfile
+++ b/src/cache/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
+FROM golang:1.24.3-alpine as builder
 
 WORKDIR /app
 
@@ -9,7 +9,7 @@ RUN go mod vendor
 RUN go mod verify
 RUN go build -mod=vendor -o cache
 
-FROM golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
+FROM golang:1.24.3-alpine
 
 RUN apk add curl
 

--- a/src/cache/Dockerfile
+++ b/src/cache/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-alpine as builder
+FROM golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
 
 WORKDIR /app
 
@@ -9,7 +9,7 @@ RUN go mod vendor
 RUN go mod verify
 RUN go build -mod=vendor -o cache
 
-FROM golang:1.24.3-alpine
+FROM golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
 
 RUN apk add curl
 


### PR DESCRIPTION
This pull request focuses on improving the security and reliability of CI/CD workflows by pinning GitHub Actions and Docker images to specific commit SHAs or digests. It also updates some workflow configurations and admin settings for deployments.

**Security and reliability improvements:**

* All GitHub Actions in workflow files (such as `actions/checkout`, `github/branch-deploy`, `GrantBirki/json-yaml-validate`, `GrantBirki/comment`, and `actions/setup-go`) are now pinned to specific commit SHAs rather than version tags, reducing the risk of unexpected changes from upstream updates. [[1]](diffhunk://#diff-20178bfee541d27c8c2296d927b63f9c6fec922b9ead4965f2e35958204baebbL19-R19) [[2]](diffhunk://#diff-38fd5517ee8c8e3d8edb6a293c6335a5a3792dfd5ca33205a6194f6fe0ff3becL17-R20) [[3]](diffhunk://#diff-b3eef5e7462dc6caa559e4c6894e18151782807d1781baec6c4930fd61a28f47L29-R40) [[4]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L21-R21) [[5]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L35-R35) [[6]](diffhunk://#diff-536c1ce31e8bf9323e3cbe04eb5301801c5b53967fe1b3790c778b8750a9513bL19-R21) [[7]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L16-R19) [[8]](diffhunk://#diff-94a85030952fbf3dfffce63b4d07b413002bb9e3dc1720283bf975891847c1abL17-R17)
* The `redis` Docker image in `docker-compose.yml` is now pinned to a specific SHA256 digest, ensuring consistent and predictable builds.

**Workflow configuration and deployment changes:**

* The `environment` configuration for the `branch-deploy.yml` workflow has been updated to use a named environment (`production`) with `deployment: false`, and the list of deployment admins has been changed to specific users (`GrantBirki,Razzmatazzz`) instead of a team and secret. [[1]](diffhunk://#diff-b3eef5e7462dc6caa559e4c6894e18151782807d1781baec6c4930fd61a28f47L17-R19) [[2]](diffhunk://#diff-b3eef5e7462dc6caa559e4c6894e18151782807d1781baec6c4930fd61a28f47L29-R40)
* The `script_stop` parameter was removed from the deploy step in `deploy.yml`, likely aligning with updated deployment script requirements.