### PR TITLE
Add Docker log rotation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,17 @@
 # To build the entire stack run 'make run'
 
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "100m"
+    max-file: "5"
+
 services:
   redis:
     container_name: redis
     image: redis:alpine3.16@sha256:2700d5097763fda285c463f4eefc3d0730a2df2a9d48e66707b19d5a5e5f23d4
     restart: unless-stopped
+    logging: *default-logging
     command:
       [
         "redis-server",
@@ -19,6 +26,7 @@ services:
   cache:
     container_name: cache
     restart: unless-stopped
+    logging: *default-logging
     build:
       context: ./src/cache
       dockerfile: ./Dockerfile


### PR DESCRIPTION
## Summary

Adds explicit Docker `json-file` log rotation for the cache and Redis services in Compose. This keeps the production stack from depending only on host-level Docker daemon defaults and caps retained container logs at five 100 MB files per service.
