### PR TITLE
Show cache Go code in Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+src/cache/*.go linguist-vendored=false
+src/cache/go.mod linguist-vendored=false
+src/cache/Dockerfile linguist-vendored=false


### PR DESCRIPTION
## Summary

Add a root `.gitattributes` override so GitHub Linguist counts the first-party Go cache service files under `src/cache`, while leaving the vendored Redis client tree excluded.

This should make the repository language graph show Go once GitHub recalculates Linguist stats.