### PR TITLE
Ignore scripts in Linguist stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 src/cache/*.go linguist-vendored=false
 src/cache/go.mod linguist-vendored=false
 src/cache/Dockerfile linguist-vendored=false
+script/* linguist-vendored=true


### PR DESCRIPTION
## Summary

Mark top-level `script/*` files as `linguist-vendored=true` so GitHub Linguist omits those Bash helper scripts from the language graph while continuing to count the first-party Go cache service files.

This is metadata-only and does not change runtime or CI behavior.